### PR TITLE
Run PEP8 on content

### DIFF
--- a/ForecastingApp/ForecastAPI/__init__.py
+++ b/ForecastingApp/ForecastAPI/__init__.py
@@ -14,10 +14,11 @@ Statsmodel depends on pystan and this demonstrates ML library installation chall
 that are overcome through the Azure Functions deployment process
 '''
 
+
 def main(req: func.HttpRequest,
          input: func.InputStream,
          output: func.Out[bytes]) -> func.HttpResponse:
-    
+
     logging.info('Python HTTP trigger function processed a request.')
 
     # If data has to be read from local csv file, you can mention the path this way

--- a/ForecastingApp/ForecastAPI/forecast.py
+++ b/ForecastingApp/ForecastAPI/forecast.py
@@ -10,6 +10,7 @@ from sklearn.metrics import mean_squared_error
 # Reference: https://machinelearningmastery.com/autoregression-models-time-series-forecasting-python/
 # This sample shows a simple time series graph prediction using autoregression model
 
+
 def predict(series):
 
     # split dataset
@@ -23,9 +24,10 @@ def predict(series):
     logging.info('Coefficients: %s' % model_fit.params)
 
     # make predictions
-    predictions = model_fit.predict(start=len(train), end=len(train)+len(test)-1, dynamic=False)
+    predictions = model_fit.predict(
+        start=len(train), end=len(train)+len(test)-1, dynamic=False)
     for i in range(len(predictions)):
-	    logging.info('predicted=%f, expected=%f' % (predictions[i], test[i]))
+        logging.info('predicted=%f, expected=%f' % (predictions[i], test[i]))
     error = mean_squared_error(test, predictions)
     logging.info('Test MSE: %.3f' % error)
     # plot results
@@ -35,7 +37,7 @@ def predict(series):
 
     # Save the plot as bytes
     buf = io.BytesIO()
-    pyplot.savefig(buf,format="png")
+    pyplot.savefig(buf, format="png")
     buf.seek(0)
     pyplotfile = buf.read()
     buf.close()


### PR DESCRIPTION
Hello! The Azure documentation team (Content & Learning) is updating existing
Python samples to conform to PEP8. This consists of (only) running `autopep8`
on content. Even if this PR contains only whitespace changes, please accept it.

If you have questions about the rationale behind this change, please email
Microsoft alias `sttramer`.